### PR TITLE
fix(filter bar): ensure unlocalized values for seconds filter seriali…

### DIFF
--- a/silk/templates/silk/inclusion/filter_bar.html
+++ b/silk/templates/silk/inclusion/filter_bar.html
@@ -1,3 +1,4 @@
+{% load silk_filters %}
 {% comment %}
 Inline collapsible filter bar — replaces the old CBP drawer.
 Must be placed inside a <form> element that POSTs to the current URL.

--- a/silk/templates/silk/inclusion/filter_bar.html
+++ b/silk/templates/silk/inclusion/filter_bar.html
@@ -15,12 +15,12 @@ Must be placed inside a <form> element that POSTs to the current URL.
                 {% for preset in time_presets %}
                 <button type="button"
                         class="silk-preset-btn {% if filters.seconds.value == preset.seconds %}silk-preset-btn--active{% endif %}"
-                        onclick="silkSetSeconds(this, '{{ preset.seconds }}')">{{ preset.label }}</button>
+                        onclick="silkSetSeconds(this, '{{ preset.seconds|unlocalize }}')">{{ preset.label }}</button>
                 {% endfor %}
             </div>
             <input type="hidden" name="filter-seconds-typ" value="SecondsFilter">
             <input type="hidden" name="filter-seconds-value" id="silk-seconds-val"
-                   value="{{ filters.seconds.value }}">
+                   value="{{ filters.seconds.value|unlocalize }}">
         </div>
 
         {# Method toggles — multi-select, active state managed by JS on init #}

--- a/silk/templatetags/silk_filters.py
+++ b/silk/templatetags/silk_filters.py
@@ -91,6 +91,16 @@ def sorted(value):
     return sorted(value)
 
 
+@register.filter
+def unlocalize(value):
+    """
+    Render values without Django's locale-aware numeric formatting.
+    """
+    if value is None:
+        return ''
+    return str(value)
+
+
 @stringfilter
 def filepath_urlify(value, autoescape=None):
     value = _urlify(value)


### PR DESCRIPTION
…zation

Apply the `unlocalize` filter to `seconds` values in the filter bar template to ensure consistent serialization and avoid localization conflicts.