### PR TITLE
fix: sync JS content type filter fix from upstream (#868)

### DIFF
--- a/silk/model_factory.py
+++ b/silk/model_factory.py
@@ -286,9 +286,10 @@ class ResponseModelFactory:
                                       , ensure_ascii=SilkyConfig().SILKY_JSON_ENSURE_ASCII)
                 except (TypeError, ValueError):
                     if content_type in content_types_json:
+                        request_pk = self.request.pk if self.request else None
                         Logger.warning(
                             'Response to request with pk %s has content type %s but was unable to parse it'
-                            % (self.request.pk, content_type)
+                            % (request_pk, content_type)
                         )
         return body, content
 


### PR DESCRIPTION
## Summary

- Cherry-picks upstream fix [jazzband/django-silk#868](https://github.com/jazzband/django-silk/pull/868): separates JS content types from JSON content types in `model_factory.py` so that unparseable JavaScript responses no longer emit spurious warnings
- Adds upstream's new `test_encoding.py` tests covering JS content type handling
- Guards `self.request.pk` in the warning path against `None` (DataCollector has no active request in test context), fixing a test failure introduced by the cherry-pick

## Test plan

- [x] `DB_ENGINE=sqlite3 .venv/bin/python -m pytest project/tests/test_encoding.py -q` — all 20 tests pass
- [x] `DB_ENGINE=sqlite3 .venv/bin/python -m pytest project/tests/ -q` — full suite green