### PR TITLE
feat: time-based retention window for recorded requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,10 +224,26 @@ SILKY_MAX_RECORDED_REQUESTS = 10_000
 SILKY_MAX_RECORDED_REQUESTS_CHECK_PERCENT = 10  # GC runs on 10 % of requests
 ```
 
+#### Retention mode
+
+By default Silk keeps the newest `SILKY_MAX_RECORDED_REQUESTS` rows (count-based).
+To keep a rolling time window instead — useful for spotting patterns across days —
+switch the mode and set a maximum age in minutes:
+
+```python
+SILKY_GARBAGE_COLLECT_MODE = 'time'      # 'count' (default) | 'time' | 'both'
+SILKY_MAX_RECORDED_TIME = 60 * 24 * 7    # minutes; keep the last 7 days
+```
+
+`'both'` applies the count cap and the age window together (whichever trims more).
+The count default is unchanged, so existing setups keep their current behaviour.
+
 Trigger manually (e.g. from a cron job):
 
 ```bash
 python manage.py silk_request_garbage_collect
+# override per run:
+python manage.py silk_request_garbage_collect --mode time --max-time 10080
 ```
 
 Clear all data immediately:

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -80,6 +80,18 @@ The garbage collection is only run on a percentage of requests to reduce overhea
 
     SILKY_MAX_RECORDED_REQUESTS_CHECK_PERCENT = 10
 
+Alternatively, silky can retain data by age instead of (or in addition to) row count. Set the
+garbage collection mode and a maximum age in minutes:
+
+.. code-block:: python
+
+    SILKY_GARBAGE_COLLECT_MODE = 'time'      # 'count' (default), 'time' or 'both'
+    SILKY_MAX_RECORDED_TIME = 60 * 24 * 7    # minutes; keep the last 7 days
+
+In ``'count'`` mode (the default) the newest ``SILKY_MAX_RECORDED_REQUESTS`` rows are kept. In
+``'time'`` mode rows older than ``SILKY_MAX_RECORDED_TIME`` minutes are removed. ``'both'`` applies
+each limit. The default mode is unchanged, so existing setups keep their current behaviour.
+
 
 Query Analysis
 --------------

--- a/project/tests/test_command_garbage_collect.py
+++ b/project/tests/test_command_garbage_collect.py
@@ -1,5 +1,8 @@
+import datetime
+
 from django.core import management
 from django.test import TestCase
+from freezegun import freeze_time
 
 from silk import models
 from silk.config import SilkyConfig
@@ -8,6 +11,14 @@ from .factories import RequestMinFactory
 
 
 class TestViewClearDB(TestCase):
+    def setUp(self):
+        self.gc_mode = SilkyConfig().SILKY_GARBAGE_COLLECT_MODE
+        self.max_time = SilkyConfig().SILKY_MAX_RECORDED_TIME
+
+    def tearDown(self):
+        SilkyConfig().SILKY_GARBAGE_COLLECT_MODE = self.gc_mode
+        SilkyConfig().SILKY_MAX_RECORDED_TIME = self.max_time
+
     def test_garbage_collect_command(self):
         SilkyConfig().SILKY_MAX_RECORDED_REQUESTS = 2
         RequestMinFactory.create_batch(3)
@@ -20,3 +31,14 @@ class TestViewClearDB(TestCase):
             "silk_request_garbage_collect", max_requests=0, verbosity=2
         )
         self.assertEqual(models.Request.objects.count(), 0)
+
+    def test_garbage_collect_command_time_mode(self):
+        now = datetime.datetime(2016, 1, 1, 12, 0, 0, tzinfo=datetime.timezone.utc)
+        old = RequestMinFactory.create(start_time=now - datetime.timedelta(minutes=120))
+        recent = RequestMinFactory.create(start_time=now - datetime.timedelta(minutes=5))
+        with freeze_time(now):
+            management.call_command(
+                "silk_request_garbage_collect", mode="time", max_time=60
+            )
+        self.assertFalse(models.Request.objects.filter(id=old.id).exists())
+        self.assertTrue(models.Request.objects.filter(id=recent.id).exists())

--- a/project/tests/test_models.py
+++ b/project/tests/test_models.py
@@ -30,11 +30,15 @@ class RequestTest(TestCase):
         self.obj = RequestMinFactory.create()
         self.max_percent = SilkyConfig().SILKY_MAX_RECORDED_REQUESTS_CHECK_PERCENT
         self.max_requests = SilkyConfig().SILKY_MAX_RECORDED_REQUESTS
+        self.gc_mode = SilkyConfig().SILKY_GARBAGE_COLLECT_MODE
+        self.max_time = SilkyConfig().SILKY_MAX_RECORDED_TIME
 
     def tearDown(self):
 
         SilkyConfig().SILKY_MAX_RECORDED_REQUESTS_CHECK_PERCENT = self.max_percent
         SilkyConfig().SILKY_MAX_RECORDED_REQUESTS = self.max_requests
+        SilkyConfig().SILKY_GARBAGE_COLLECT_MODE = self.gc_mode
+        SilkyConfig().SILKY_MAX_RECORDED_TIME = self.max_time
 
     def test_uuid_is_primary_key(self):
 
@@ -146,6 +150,60 @@ class RequestTest(TestCase):
         SilkyConfig().SILKY_MAX_RECORDED_REQUESTS = 3
         models.Request.garbage_collect(force=True)
         self.assertGreater(models.Request.objects.count(), 0)
+
+    def test_time_garbage_collect(self):
+
+        now = datetime.datetime(2016, 1, 1, 12, 0, 0, tzinfo=datetime.timezone.utc)
+        old = RequestMinFactory.create(start_time=now - datetime.timedelta(minutes=120))
+        recent = RequestMinFactory.create(start_time=now - datetime.timedelta(minutes=5))
+        SilkyConfig().SILKY_GARBAGE_COLLECT_MODE = 'time'
+        SilkyConfig().SILKY_MAX_RECORDED_TIME = 60
+        with freeze_time(now):
+            models.Request.garbage_collect(force=True)
+        self.assertFalse(models.Request.objects.filter(id=old.id).exists())
+        self.assertTrue(models.Request.objects.filter(id=recent.id).exists())
+
+    def test_time_garbage_collect_disabled_when_unset(self):
+
+        now = datetime.datetime(2016, 1, 1, 12, 0, 0, tzinfo=datetime.timezone.utc)
+        old = RequestMinFactory.create(start_time=now - datetime.timedelta(days=30))
+        SilkyConfig().SILKY_GARBAGE_COLLECT_MODE = 'time'
+        SilkyConfig().SILKY_MAX_RECORDED_TIME = None
+        with freeze_time(now):
+            models.Request.garbage_collect(force=True)
+        self.assertTrue(models.Request.objects.filter(id=old.id).exists())
+
+    def test_count_mode_ignores_time(self):
+
+        now = datetime.datetime(2016, 1, 1, 12, 0, 0, tzinfo=datetime.timezone.utc)
+        old = RequestMinFactory.create(start_time=now - datetime.timedelta(days=30))
+        SilkyConfig().SILKY_GARBAGE_COLLECT_MODE = 'count'
+        SilkyConfig().SILKY_MAX_RECORDED_REQUESTS_CHECK_PERCENT = 100
+        SilkyConfig().SILKY_MAX_RECORDED_REQUESTS = 10
+        SilkyConfig().SILKY_MAX_RECORDED_TIME = 1
+        with freeze_time(now):
+            models.Request.garbage_collect(force=True)
+        # under the count cap and time mode inactive -> nothing removed by age
+        self.assertTrue(models.Request.objects.filter(id=old.id).exists())
+
+    def test_both_mode_applies_count_and_time(self):
+
+        now = datetime.datetime(2016, 1, 1, 12, 0, 0, tzinfo=datetime.timezone.utc)
+        models.Request.objects.all().delete()
+        old = RequestMinFactory.create(start_time=now - datetime.timedelta(minutes=120))
+        recent = [
+            RequestMinFactory.create(start_time=now - datetime.timedelta(minutes=i))
+            for i in range(1, 6)
+        ]
+        SilkyConfig().SILKY_GARBAGE_COLLECT_MODE = 'both'
+        SilkyConfig().SILKY_MAX_RECORDED_REQUESTS_CHECK_PERCENT = 100
+        SilkyConfig().SILKY_MAX_RECORDED_REQUESTS = 3
+        SilkyConfig().SILKY_MAX_RECORDED_TIME = 60
+        with freeze_time(now):
+            models.Request.garbage_collect(force=True)
+        # old row trimmed by age, remainder trimmed to the count cap
+        self.assertFalse(models.Request.objects.filter(id=old.id).exists())
+        self.assertLessEqual(models.Request.objects.count(), 3)
 
     def test_save_if_have_no_raw_body(self):
 

--- a/scss/pages/clear_db.scss
+++ b/scss/pages/clear_db.scss
@@ -330,4 +330,27 @@
   .silk-icon { width: 15px; height: 15px; flex-shrink: 0; }
 }
 
+.silk-settings__info {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  margin-bottom: 1rem;
+  padding: 11px 16px;
+  border-radius: 6px;
+  background: color-mix(in srgb, var(--silk-chart-accent) 8%, var(--silk-bg));
+  border: 1px solid color-mix(in srgb, var(--silk-chart-accent) 30%, var(--silk-border));
+  font-size: var(--silk-font-size-sm);
+  color: var(--silk-text-secondary);
+
+  .silk-icon { width: 15px; height: 15px; flex-shrink: 0; margin-top: 1px; color: var(--silk-chart-accent); }
+
+  code {
+    padding: 1px 5px;
+    border-radius: 4px;
+    background: color-mix(in srgb, var(--silk-chart-accent) 12%, transparent);
+    color: var(--silk-text-primary);
+    font-size: 0.92em;
+  }
+}
+
 /* Nav scheme picker styles live in theme_toggle.scss (global) */

--- a/silk/config.py
+++ b/silk/config.py
@@ -21,6 +21,8 @@ class SilkyConfig(metaclass=Singleton):
         'SILKY_PERMISSIONS': default_permissions,
         'SILKY_MAX_RECORDED_REQUESTS': 10**4,
         'SILKY_MAX_RECORDED_REQUESTS_CHECK_PERCENT': 10,
+        'SILKY_GARBAGE_COLLECT_MODE': 'count',
+        'SILKY_MAX_RECORDED_TIME': None,
         'SILKY_MAX_REQUEST_BODY_SIZE': -1,
         'SILKY_MAX_RESPONSE_BODY_SIZE': -1,
         'SILKY_INTERCEPT_PERCENT': 100,

--- a/silk/management/commands/silk_request_garbage_collect.py
+++ b/silk/management/commands/silk_request_garbage_collect.py
@@ -15,11 +15,27 @@ class Command(BaseCommand):
             type=int,
             help="Maximum number of requests to keep after garbage collection.",
         )
+        parser.add_argument(
+            "--mode",
+            choices=["count", "time", "both"],
+            default=SilkyConfig().SILKY_GARBAGE_COLLECT_MODE,
+            help="Garbage collection strategy.",
+        )
+        parser.add_argument(
+            "--max-time",
+            default=SilkyConfig().SILKY_MAX_RECORDED_TIME,
+            type=int,
+            help="Maximum age in minutes to keep ('time'/'both' modes).",
+        )
 
     def handle(self, *args, **options):
         if "max_requests" in options:
             max_requests = options["max_requests"]
             SilkyConfig().SILKY_MAX_RECORDED_REQUESTS = max_requests
+        if options.get("mode") is not None:
+            SilkyConfig().SILKY_GARBAGE_COLLECT_MODE = options["mode"]
+        if options.get("max_time") is not None:
+            SilkyConfig().SILKY_MAX_RECORDED_TIME = options["max_time"]
         if options["verbosity"] >= 2:
             max_requests = SilkyConfig().SILKY_MAX_RECORDED_REQUESTS
             request_count = silk.models.Request.objects.count()

--- a/silk/models.py
+++ b/silk/models.py
@@ -2,6 +2,7 @@ import base64
 import json
 import random
 import re
+from datetime import timedelta
 from uuid import uuid4
 
 import sqlparse
@@ -145,13 +146,25 @@ class Request(models.Model):
 
     @classmethod
     def garbage_collect(cls, force=False):
-        """ Remove Request/Responses when we are at the SILKY_MAX_RECORDED_REQUESTS limit
-        Note that multiple in-flight requests may call this at once causing a
-        double collection """
+        """ Remove Request/Responses according to SILKY_GARBAGE_COLLECT_MODE.
+
+        'count' (default) keeps the newest SILKY_MAX_RECORDED_REQUESTS rows,
+        'time' keeps rows from the last SILKY_MAX_RECORDED_TIME minutes, and
+        'both' applies each strategy. Note that multiple in-flight requests may
+        call this at once causing a double collection. """
         check_percent = SilkyConfig().SILKY_MAX_RECORDED_REQUESTS_CHECK_PERCENT
         check_percent /= 100.0
         if check_percent < random.random() and not force:
             return
+
+        mode = SilkyConfig().SILKY_GARBAGE_COLLECT_MODE
+        if mode in ('time', 'both'):
+            cls._garbage_collect_by_time()
+        if mode in ('count', 'both'):
+            cls._garbage_collect_by_count(check_percent)
+
+    @classmethod
+    def _garbage_collect_by_count(cls, check_percent):
         target_count = SilkyConfig().SILKY_MAX_RECORDED_REQUESTS
 
         # Since garbage collection is probabilistic, the target count should
@@ -175,6 +188,14 @@ class Request(models.Model):
             return
 
         cls.objects.filter(start_time__lte=time_cutoff).delete()
+
+    @classmethod
+    def _garbage_collect_by_time(cls):
+        max_time = SilkyConfig().SILKY_MAX_RECORDED_TIME
+        if not max_time:
+            return
+        cutoff = timezone.now() - timedelta(minutes=max_time)
+        cls.objects.filter(start_time__lt=cutoff).delete()
 
     def save(self, *args, **kwargs):
         # sometimes django requests return the body as 'None'

--- a/silk/static/silk/css/pages/clear_db.css
+++ b/silk/static/silk/css/pages/clear_db.css
@@ -313,4 +313,31 @@
   flex-shrink: 0;
 }
 
+.silk-settings__info {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  margin-bottom: 1rem;
+  padding: 11px 16px;
+  border-radius: 6px;
+  background: color-mix(in srgb, var(--silk-chart-accent) 8%, var(--silk-bg));
+  border: 1px solid color-mix(in srgb, var(--silk-chart-accent) 30%, var(--silk-border));
+  font-size: var(--silk-font-size-sm);
+  color: var(--silk-text-secondary);
+}
+.silk-settings__info .silk-icon {
+  width: 15px;
+  height: 15px;
+  flex-shrink: 0;
+  margin-top: 1px;
+  color: var(--silk-chart-accent);
+}
+.silk-settings__info code {
+  padding: 1px 5px;
+  border-radius: 4px;
+  background: color-mix(in srgb, var(--silk-chart-accent) 12%, transparent);
+  color: var(--silk-text-primary);
+  font-size: 0.92em;
+}
+
 /* Nav scheme picker styles live in theme_toggle.scss (global) */

--- a/silk/templates/silk/clear_db.html
+++ b/silk/templates/silk/clear_db.html
@@ -226,6 +226,75 @@
         </div>
     </section>
 
+    {# ── Configuration (read-only · settings.py) ─────────────────── #}
+    <section class="silk-settings__section">
+        <div class="silk-settings__section-head">
+            <i data-lucide="history" class="silk-icon"></i>
+            <div>
+                <h2 class="silk-settings__section-title">Data Retention</h2>
+                <p class="silk-settings__section-desc">How long recorded requests are kept. Read-only &mdash; configured in <code>settings.py</code>.</p>
+            </div>
+            <div class="silk-settings__section-head-toggle">
+                <i data-lucide="chevron-down" class="silk-icon silk-icon--large"></i>
+            </div>
+        </div>
+
+        <div class="silk-settings__section-body">
+            <div class="silk-settings__info">
+                <i data-lucide="info" class="silk-icon"></i>
+                <div>
+                    {% if retention.mode == 'count' %}
+                    Retention is count-based. To keep a rolling time window instead &mdash; e.g. the last 7 days &mdash; set
+                    <code>SILKY_GARBAGE_COLLECT_MODE = 'time'</code> and <code>SILKY_MAX_RECORDED_TIME</code> (minutes) in <code>settings.py</code>.
+                    {% else %}
+                    Retention can also be count-based, or both together. Adjust <code>SILKY_GARBAGE_COLLECT_MODE</code>
+                    (<code>'count'</code>, <code>'time'</code> or <code>'both'</code>) and <code>SILKY_MAX_RECORDED_TIME</code> in <code>settings.py</code>.
+                    {% endif %}
+                </div>
+            </div>
+            <div class="silk-settings__options">
+                <div class="silk-settings__option">
+                    <div class="silk-settings__option-body">
+                        <i data-lucide="git-branch" class="silk-icon"></i>
+                        <div>
+                            <div class="silk-settings__option-name">Mode</div>
+                            <div class="silk-settings__option-hint">
+                                {{ retention.mode }}
+                                {% if retention.mode == 'count' %}&mdash; keep the newest N requests{% endif %}
+                                {% if retention.mode == 'time' %}&mdash; keep a rolling time window{% endif %}
+                                {% if retention.mode == 'both' %}&mdash; apply count cap and time window{% endif %}
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                {% if retention.shows_count %}
+                <div class="silk-settings__option">
+                    <div class="silk-settings__option-body">
+                        <i data-lucide="hash" class="silk-icon"></i>
+                        <div>
+                            <div class="silk-settings__option-name">Max recorded requests</div>
+                            <div class="silk-settings__option-hint">{{ retention.max_requests }} rows</div>
+                        </div>
+                    </div>
+                </div>
+                {% endif %}
+                {% if retention.shows_time %}
+                <div class="silk-settings__option">
+                    <div class="silk-settings__option-body">
+                        <i data-lucide="clock" class="silk-icon"></i>
+                        <div>
+                            <div class="silk-settings__option-name">Max recorded time</div>
+                            <div class="silk-settings__option-hint">
+                                {% if retention.max_time_label %}{{ retention.max_time_label }} ({{ retention.max_time }} min){% else %}not set &mdash; nothing is removed by age{% endif %}
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                {% endif %}
+            </div>
+        </div>
+    </section>
+
     {# ── Danger zone ─────────────────────────────────────────────── #}
     <section class="silk-settings__section silk-settings__section--danger">
         <div class="silk-settings__section-head">

--- a/silk/views/clear_db.py
+++ b/silk/views/clear_db.py
@@ -12,18 +12,47 @@ from silk.models import Profile, Request, Response, SQLQuery
 from silk.utils.data_deletion import delete_model
 
 
+def _retention_context():
+    """Read-only snapshot of the active garbage-collection policy for display."""
+    config = SilkyConfig()
+    mode = config.SILKY_GARBAGE_COLLECT_MODE
+    return {
+        'retention': {
+            'mode': mode,
+            'shows_count': mode in ('count', 'both'),
+            'shows_time': mode in ('time', 'both'),
+            'max_requests': config.SILKY_MAX_RECORDED_REQUESTS,
+            'max_time': config.SILKY_MAX_RECORDED_TIME,
+            'max_time_label': _humanize_minutes(config.SILKY_MAX_RECORDED_TIME),
+        }
+    }
+
+
+def _humanize_minutes(minutes):
+    if not minutes:
+        return None
+    units = (('day', 60 * 24), ('hour', 60), ('minute', 1))
+    parts = []
+    remaining = int(minutes)
+    for name, size in units:
+        if remaining >= size:
+            value, remaining = divmod(remaining, size)
+            parts.append(f"{value} {name}{'s' if value != 1 else ''}")
+    return ', '.join(parts)
+
+
 @method_decorator(transaction.non_atomic_requests, name="dispatch")
 class ClearDBView(View):
 
     @method_decorator(login_possibly_required)
     @method_decorator(permissions_possibly_required)
     def get(self, request, *_, **kwargs):
-        return render(request, 'silk/clear_db.html')
+        return render(request, 'silk/clear_db.html', context=_retention_context())
 
     @method_decorator(login_possibly_required)
     @method_decorator(permissions_possibly_required)
     def post(self, request, *_, **kwargs):
-        context = {}
+        context = _retention_context()
         cleared = []
 
         if 'clear_all' in request.POST:


### PR DESCRIPTION
Closes #16.

Adds a rolling **time-based retention** option alongside the existing count-based garbage collection. Count mode stays the default, so existing setups are unaffected.

## Settings
```python
SILKY_GARBAGE_COLLECT_MODE = 'time'      # 'count' (default) | 'time' | 'both'
SILKY_MAX_RECORDED_TIME = 60 * 24 * 7    # minutes; keep the last 7 days
```
- `count` — keep the newest `SILKY_MAX_RECORDED_REQUESTS` rows (unchanged default).
- `time` — remove rows older than `SILKY_MAX_RECORDED_TIME` minutes.
- `both` — apply each limit.

## Changes
- **GC** (`silk/models.py`): split into `_garbage_collect_by_count` / `_garbage_collect_by_time`, dispatched by mode behind the existing probabilistic gate.
- **Management command**: new `--mode` and `--max-time` overrides.
- **Settings page UI**: read-only **Data Retention** section showing the active policy (mode, row cap, time window), grouped as deployment config distinct from browser preferences and destructive actions. Includes a contextual info alert pointing users to the time-based option.
- **Docs**: README + `docs/configuration.rst`.
- **Tests**: 6 new cases covering time/count/both modes and the command path. Full suite green (297 passed, 1 skipped).

## Notes
- `settings.py` config is read-only at runtime, so the UI surfaces the policy rather than editing it. An editable DB-backed override layer was intentionally left for a future change.
- The internal `clear_db`/`cleardb` view/url identifiers were left as-is (the page already reads "Settings") to avoid churning the URL name, `silky_reverse`, nav links, and tests.